### PR TITLE
Fix: Randomize FBM noise pattern on new instance

### DIFF
--- a/utils/FractionalBrownianNoise.js
+++ b/utils/FractionalBrownianNoise.js
@@ -3,7 +3,7 @@ class FractionalBrownianNoise {
     constructor() {
         this.NUM_OCTAVES = 5;
         // Pre-calculate rotation matrix components
-        const rotationAngle = 0.5;
+        const rotationAngle = Math.random() * Math.PI * 2;
         this.cosAngle = Math.cos(rotationAngle);
         this.sinAngle = Math.sin(rotationAngle);
     }


### PR DESCRIPTION
The FractionalBrownianNoise class was previously initialized with a constant rotation angle, causing the "Randomize" button to produce the same pattern repeatedly for the FBM noise type.

This change modifies the constructor of FractionalBrownianNoise to initialize its internal rotationAngle with a random value (Math.random() * Math.PI * 2). This ensures that each time a new instance of FractionalBrownianNoise is created (e.g., when clicking "Randomize"), a new and visually distinct noise pattern is generated.